### PR TITLE
mark-devkit: Bump virtual/eject-0-r1

### DIFF
--- a/virtual/eject/eject-0-r1.ebuild
+++ b/virtual/eject/eject-0-r1.ebuild
@@ -1,0 +1,10 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+DESCRIPTION="Virtual for the eject command"
+SLOT="0"
+KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux"
+
+RDEPEND="|| ( >=sys-apps/util-linux-2.22 sys-block/eject-bsd )"


### PR DESCRIPTION
Automatic bump of package virtual/eject-0-r1 for branch mark-iii by mark-bot