### PR TITLE
mark-devkit: Bump media-video/kino-1.3.4-r2

### DIFF
--- a/media-video/kino/kino-1.3.4-r2.ebuild
+++ b/media-video/kino/kino-1.3.4-r2.ebuild
@@ -1,4 +1,3 @@
-# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +9,7 @@ SRC_URI="mirror://sourceforge/kino/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ppc ppc64 x86"
+KEYWORDS="*"
 IUSE="alsa dvdr gpac lame libav quicktime sox vorbis"
 
 # Optional dependency on cinelerra-cvs (as a replacement for libquicktime)


### PR DESCRIPTION
Automatic bump of package media-video/kino-1.3.4-r2 for branch mark-iii by mark-bot