### PR TITLE
mark-devkit: Bump media-libs/libtiger-0.3.4-r2

### DIFF
--- a/media-libs/libtiger/libtiger-0.3.4-r2.ebuild
+++ b/media-libs/libtiger/libtiger-0.3.4-r2.ebuild
@@ -1,4 +1,3 @@
-# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,7 +9,7 @@ SRC_URI="https://libtiger.googlecode.com/files/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="alpha amd64 arm arm64 ppc ppc64 sparc x86 ~amd64-fbsd ~x86-fbsd"
+KEYWORDS="*"
 IUSE="doc"
 
 RDEPEND="x11-libs/pango[${MULTILIB_USEDEP}]


### PR DESCRIPTION
Automatic bump of package media-libs/libtiger-0.3.4-r2 for branch mark-iii by mark-bot