### PR TITLE
mark-devkit: Bump media-video/dvdauthor-0.7.2-r3

### DIFF
--- a/media-video/dvdauthor/dvdauthor-0.7.2-r3.ebuild
+++ b/media-video/dvdauthor/dvdauthor-0.7.2-r3.ebuild
@@ -1,7 +1,6 @@
-# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 inherit autotools eutils flag-o-matic toolchain-funcs
 
 DESCRIPTION="Tools for generating DVD files to be played on standalone DVD players"
@@ -10,7 +9,7 @@ SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ppc ppc64 ~sparc x86"
+KEYWORDS="*"
 IUSE="graphicsmagick +imagemagick"
 REQUIRED_USE="^^ ( graphicsmagick imagemagick )"
 


### PR DESCRIPTION
Automatic bump of package media-video/dvdauthor-0.7.2-r3 for branch mark-iii by mark-bot