### PR TITLE
mark-devkit: Bump media-libs/libbs2b-3.1.0-r3

### DIFF
--- a/media-libs/libbs2b/libbs2b-3.1.0-r3.ebuild
+++ b/media-libs/libbs2b/libbs2b-3.1.0-r3.ebuild
@@ -1,4 +1,3 @@
-# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7


### PR DESCRIPTION
Automatic bump of package media-libs/libbs2b-3.1.0-r3 for branch mark-unstable by mark-bot