### PR TITLE
mark-devkit: Bump media-libs/libopenraw-0.1.3-r1

### DIFF
--- a/media-libs/libopenraw/libopenraw-0.1.3-r1.ebuild
+++ b/media-libs/libopenraw/libopenraw-0.1.3-r1.ebuild
@@ -1,7 +1,6 @@
-# Copyright 1999-2018 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit gnome2-utils
 
@@ -11,7 +10,7 @@ SRC_URI="https://${PN}.freedesktop.org/download/${P}.tar.bz2"
 
 LICENSE="GPL-3 LGPL-3"
 SLOT="0/7"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~x64-macos ~x86-solaris"
+KEYWORDS="*"
 IUSE="gtk static-libs test"
 
 RDEPEND="


### PR DESCRIPTION
Automatic bump of package media-libs/libopenraw-0.1.3-r1 for branch mark-unstable by mark-bot