### PR TITLE
mark-devkit: Bump media-libs/raptor-2.0.15-r3

### DIFF
--- a/media-libs/raptor/raptor-2.0.15-r3.ebuild
+++ b/media-libs/raptor/raptor-2.0.15-r3.ebuild
@@ -1,4 +1,3 @@
-# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +13,7 @@ SRC_URI="http://download.librdf.org/source/${MY_P}.tar.gz"
 
 LICENSE="Apache-2.0 GPL-2 LGPL-2.1"
 SLOT="2"
-KEYWORDS="alpha amd64 arm arm64 hppa ia64 ppc ppc64 sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="*"
 IUSE="+curl debug json static-libs unicode"
 
 DEPEND="


### PR DESCRIPTION
Automatic bump of package media-libs/raptor-2.0.15-r3 for branch mark-unstable by mark-bot