### PR TITLE
mark-devkit: Bump media-video/vcdimager-2.0.1-r1

### DIFF
--- a/media-video/vcdimager/vcdimager-2.0.1-r1.ebuild
+++ b/media-video/vcdimager/vcdimager-2.0.1-r1.ebuild
@@ -1,4 +1,3 @@
-# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +10,7 @@ SRC_URI="mirror://gnu/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sh sparc x86 ~amd64-fbsd ~x86-fbsd"
+KEYWORDS="*"
 IUSE="static-libs +xml"
 
 RDEPEND="


### PR DESCRIPTION
Automatic bump of package media-video/vcdimager-2.0.1-r1 for branch mark-unstable by mark-bot