### PR TITLE
mark-devkit: Bump media-libs/libavif-1.2.1-r1

### DIFF
--- a/media-libs/libavif/libavif-1.2.1-r1.ebuild
+++ b/media-libs/libavif/libavif-1.2.1-r1.ebuild
@@ -48,7 +48,6 @@ src_configure() {
 		# Use system libraries.
 		-DAVIF_LOCAL_ZLIBPNG=OFF
 		-DAVIF_LOCAL_JPEG=OFF
-		-DAVIF_LIBYUV=OFF
 
 		-DAVIF_BUILD_GDK_PIXBUF=$(usex gdk-pixbuf ON OFF)
 		-DAVIF_ENABLE_WERROR=OFF


### PR DESCRIPTION
Automatic bump of package media-libs/libavif-1.2.1-r1 for branch mark-unstable by mark-bot