### PR TITLE
mark-devkit: Bump media-video/ffmpeg-4.3.1-r3

### DIFF
--- a/media-video/ffmpeg/ffmpeg-4.3.1-r3.ebuild
+++ b/media-video/ffmpeg/ffmpeg-4.3.1-r3.ebuild
@@ -203,7 +203,7 @@ RDEPEND="
 	jack? ( virtual/jack[${MULTILIB_USEDEP}] )
 	jpeg2k? ( >=media-libs/openjpeg-2:2[${MULTILIB_USEDEP}] )
 	libaom? ( >=media-libs/libaom-1.0.0-r1:=[${MULTILIB_USEDEP}] )
-	libaribb24? ( >=media-libs/aribb24-1.0.3[${MULTILIB_USEDEP}] )
+	libaribb24? ( >=media-libs/aribb24-1.0.3-r2[${MULTILIB_USEDEP}] )
 	libass? ( >=media-libs/libass-0.10.2:=[${MULTILIB_USEDEP}] )
 	libcaca? ( >=media-libs/libcaca-0.99_beta18-r1[${MULTILIB_USEDEP}] )
 	libdrm? ( x11-libs/libdrm[${MULTILIB_USEDEP}] )


### PR DESCRIPTION
Automatic bump of package media-video/ffmpeg-4.3.1-r3 for branch mark-unstable by mark-bot