### PR TITLE
mark-devkit: Bump media-libs/alsa-lib-1.2.11-r1

### DIFF
--- a/media-libs/alsa-lib/alsa-lib-1.2.11-r1.ebuild
+++ b/media-libs/alsa-lib/alsa-lib-1.2.11-r1.ebuild
@@ -24,7 +24,7 @@ RDEPEND="python? ( ${PYTHON_DEPS} )
 DEPEND="${RDEPEND}"
 
 PATCHES=(
-	"${FILESDIR}/${PN}-1.1.6-missing_files.patch" #652422
+	"${REPODIR}/media-sound/files/${PN}/${PN}-1.1.6-missing_files.patch" #652422
 )
 
 pkg_setup() {


### PR DESCRIPTION
Automatic bump of package media-libs/alsa-lib-1.2.11-r1 for branch mark-unstable by mark-bot