### PR TITLE
mark-devkit: Bump media-plugins/alsa-plugins-1.2.7.1-r1

### DIFF
--- a/media-plugins/alsa-plugins/alsa-plugins-1.2.7.1-r1.ebuild
+++ b/media-plugins/alsa-plugins/alsa-plugins-1.2.7.1-r1.ebuild
@@ -74,9 +74,9 @@ multilib_src_install_all() {
 		# install ALSA configuration files
 		# making PA to be used by alsa clients
 		insinto /usr/share/alsa
-		doins ${FILESDIR}/pulse-default.conf
+		doins ${REPODIR}/media-sound/files/${PN}/pulse-default.conf
 		insinto /usr/share/alsa/alsa.conf.d
-		doins ${FILESDIR}/51-pulseaudio-probe.conf
+		doins ${REPODIR}/media-sound/files/${PN}/51-pulseaudio-probe.conf
 		# bug #410261, comment 5+
 		# seems to work fine without any path
 		sed \


### PR DESCRIPTION
Automatic bump of package media-plugins/alsa-plugins-1.2.7.1-r1 for branch mark-unstable by mark-bot