### PR TITLE
mark-devkit: Bump media-sound/alsa-utils-1.2.11-r1

### DIFF
--- a/media-sound/alsa-utils/alsa-utils-1.2.11-r1.ebuild
+++ b/media-sound/alsa-utils/alsa-utils-1.2.11-r1.ebuild
@@ -23,7 +23,7 @@ RDEPEND="${CDEPEND}
 BDEPEND="virtual/pkgconfig"
 
 PATCHES=(
-	${FILESDIR}/${PN}-1.1.8-missing_header.patch
+	${REPODIR}/media-sound/files/${PN}/${PN}-1.1.8-missing_header.patch
 )
 
 src_configure() {
@@ -47,11 +47,11 @@ src_install() {
 	default
 	dodoc seq/*/README.*
 
-	newinitd ${FILESDIR}/alsasound.initd-r8 alsasound
-	newconfd ${FILESDIR}/alsasound.confd-r4 alsasound
+	newinitd ${REPODIR}/media-sound/files/${PN}/alsasound.initd-r8 alsasound
+	newconfd ${REPODIR}/media-sound/files/${PN}/alsasound.confd-r4 alsasound
 
 	insinto /etc/modprobe.d
-	newins ${FILESDIR}/alsa-modules.conf-rc alsa.conf
+	newins ${REPODIR}/media-sound/files/${PN}/alsa-modules.conf-rc alsa.conf
 
 	keepdir /var/lib/alsa
 


### PR DESCRIPTION
Automatic bump of package media-sound/alsa-utils-1.2.11-r1 for branch mark-unstable by mark-bot