### PR TITLE
mark-devkit: Bump media-video/transcode-1.1.7-r7

### DIFF
--- a/media-video/transcode/transcode-1.1.7-r7.ebuild
+++ b/media-video/transcode/transcode-1.1.7-r7.ebuild
@@ -94,9 +94,6 @@ src_configure() {
 	local myconf
 	use x86 && myconf="$(use_enable !pic x86-textrels)" #271476
 
-	# Fix imagemagick detection
-	export CPPFLAGS="$CPPFLAGS -DMAGICKCORE_HDRI_ENABLE=1 -DMAGICKCORE_QUANTUM_DEPTH=16"
-
 	local myeconfargs=(
 		$(use_enable cpu_flags_x86_mmx mmx)
 		$(use_enable cpu_flags_x86_3dnow 3dnow)


### PR DESCRIPTION
Automatic bump of package media-video/transcode-1.1.7-r7 for branch mark-iii by mark-bot