### PR TITLE
mark-devkit: Bump media-libs/opencv-4.11.0-r1

### DIFF
--- a/media-libs/opencv/opencv-4.11.0-r1.ebuild
+++ b/media-libs/opencv/opencv-4.11.0-r1.ebuild
@@ -243,17 +243,6 @@ src_prepare() {
 	sed -e '/ocv_install_3rdparty_licenses/d' \
 		-i cmake/OpenCVDetectOpenCL.cmake || die
 
-	sed -e '/ocv_install_3rdparty_licenses/d' \
-		-e '/ocv_add_external_target/d' \
-		-e '/set(CUSTOM_STATUS_flatbuffers/d' \
-		-e '/flatbuffers_VERSION /d' \
-		-i cmake/OpenCVDetectFlatbuffers.cmake || die 
-
-	# Drop flatbuffers version check
-	sed -e 's|FLATBUFFERS_VERSION_MINOR == 5|FLATBUFFERS_VERSION_MINOR == FLATBUFFERS_VERSION_MINOR|g' \
-		-e 's|FLATBUFFERS_VERSION_REVISION == 9|FLATBUFFERS_VERSION_REVISION == FLATBUFFERS_VERSION_REVISION|g' \
-		-i modules/dnn/misc/tflite/schema_generated.h || die 
-
 	if use examples; then
 		sed -i 's/\(opencv_dnn\)/\1\n  opencv_gapi/' samples/cpp/CMakeLists.txt  || die
 	fi
@@ -264,7 +253,6 @@ multilib_src_configure() {
 	GLOBALCMAKEARGS=(
 	# Optional 3rd party components
 	# ===================================================
-		-DOPENCV_GENERATE_PKGCONFIG=ON
 		-DENABLE_DOWNLOAD=OFF
 		-DWITH_1394=$(usex ieee1394)
 	#	-DWITH_AVFOUNDATION=OFF # IOS


### PR DESCRIPTION
Automatic bump of package media-libs/opencv-4.11.0-r1 for branch mark-unstable by mark-bot