### PR TITLE
mark-devkit: [mark-iii] Bump media-sound/playerctl-2.4.1-r1

### DIFF
--- a/media-sound/playerctl/playerctl-2.4.1-r1.ebuild
+++ b/media-sound/playerctl/playerctl-2.4.1-r1.ebuild
@@ -20,7 +20,6 @@ DEPEND="${RDEPEND}"
 BDEPEND="
 	doc? ( dev-util/gtk-doc )
 	dev-util/gdbus-codegen
-	dev-util/glib-utils
 	virtual/pkgconfig
 "
 


### PR DESCRIPTION
Automatic bump of package media-sound/playerctl-2.4.1-r1 for branch mark-iii by mark-bot