### PR TITLE
mark-devkit: [mark-iii] Bump media-gfx/inkscape-1.4.3-r1

### DIFF
--- a/media-gfx/inkscape/inkscape-1.4.3-r1.ebuild
+++ b/media-gfx/inkscape/inkscape-1.4.3-r1.ebuild
@@ -75,7 +75,7 @@ CDEPEND="${PYTHON_DEPS}
 	)
 	
 "
-BDEPEND="dev-util/glib-utils
+BDEPEND="
 	dev-util/intltool
 	sys-devel/gettext
 	virtual/pkgconfig


### PR DESCRIPTION
Automatic bump of package media-gfx/inkscape-1.4.3-r1 for branch mark-iii by mark-bot