### PR TITLE
mark-devkit: [mark-31] Bump media-libs/gst-plugins-good-1.26.10-r1

### DIFF
--- a/media-libs/gst-plugins-good/gst-plugins-good-1.26.10-r1.ebuild
+++ b/media-libs/gst-plugins-good/gst-plugins-good-1.26.10-r1.ebuild
@@ -65,7 +65,7 @@ src_configure() {
 	  -Dpng=enabled
 	  -Dsoup=enabled
 	  -Dtaglib=enabled
-	  -Dv4l=enabled
+	  -Dv4l2=enabled
 	  -Dvpx=enabled
 	  -Dwavpack=enabled
 	  $(meson_feature flac)


### PR DESCRIPTION
Automatic bump of package media-libs/gst-plugins-good-1.26.10-r1 for branch mark-31 by mark-bot