### PR TITLE
mark-devkit: [mark-iii] Bump media-libs/libcdr-0.1.8-r1

### DIFF
--- a/media-libs/libcdr/libcdr-0.1.8-r1.ebuild
+++ b/media-libs/libcdr/libcdr-0.1.8-r1.ebuild
@@ -13,7 +13,7 @@ KEYWORDS="*"
 IUSE="doc"
 BDEPEND="sys-devel/libtool
 	virtual/pkgconfig
-	doc? ( app-text/doxygen )
+	doc? ( app-doc/doxygen )
 	
 "
 RDEPEND="dev-libs/icu:=


### PR DESCRIPTION
Automatic bump of package media-libs/libcdr-0.1.8-r1 for branch mark-iii by mark-bot