### PR TITLE
mark-devkit: [mark-iii] Bump media-libs/libvisio-0.1.10-r1

### DIFF
--- a/media-libs/libvisio/libvisio-0.1.10-r1.ebuild
+++ b/media-libs/libvisio/libvisio-0.1.10-r1.ebuild
@@ -11,7 +11,7 @@ SLOT="0"
 KEYWORDS="*"
 IUSE="doc tools"
 BDEPEND="virtual/pkgconfig
-	doc? ( app-text/doxygen )
+	doc? ( app-doc/doxygen )
 	
 "
 RDEPEND="dev-libs/icu:=


### PR DESCRIPTION
Automatic bump of package media-libs/libvisio-0.1.10-r1 for branch mark-iii by mark-bot