### PR TITLE
mark-devkit: [mark-31] Bump media-sound/spotify-1.2.60.564-r1

### DIFF
--- a/media-sound/spotify/spotify-1.2.60.564-r1.ebuild
+++ b/media-sound/spotify/spotify-1.2.60.564-r1.ebuild
@@ -25,7 +25,7 @@ RDEPEND="
 	media-libs/harfbuzz
 	media-libs/mesa[X(+)]
 	net-misc/curl[ssl]
-	net-print/cups[ssl]
+	net-print/cups
 	pulseaudio? ( media-sound/pulseaudio )
 	!pulseaudio? ( media-sound/apulse )
 	systray? ( gnome-extra/gnome-integration-spotify )


### PR DESCRIPTION
Automatic bump of package media-sound/spotify-1.2.60.564-r1 for branch mark-31 by mark-bot